### PR TITLE
Add a GitHub Action to run the Django tests

### DIFF
--- a/.github/workflows/django_test.yml
+++ b/.github/workflows/django_test.yml
@@ -1,0 +1,31 @@
+name: django_test
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  django_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements397.txt
+      - run: pip list
+      - run: pip freeze
+      - run: python -m pip freeze
+      - name: Run Tests
+        env:
+          DJANGO_SETTINGS_MODULE: whg.settings
+          SECRET_KEY: 69tgugtg%^fgJO&*&
+          # DB_NAME: mydb
+          # DB_USER: userdb
+          # DB_PASSWORD: password
+          DJANGO_ALLOWED_HOSTS: localhost 127.0.0.1 [::1]
+          DEBUG_MODE: False
+          # TIME_ZONE: America/Chicago
+          # CACHE_KEY_PREFIX: WHG
+        run: python ./manage.py test

--- a/requirements397.txt
+++ b/requirements397.txt
@@ -20,7 +20,7 @@ botocore==1.24.18
 bs4==0.0.1
 cached-property==1.5.2
 cchardet==2.1.7
-celery==4.4.7
+celery
 redis==3.5.3
 celery-progress==0.1.0
 certifi==2021.10.8
@@ -61,7 +61,7 @@ django-leaflet==0.24.0
 django-mathfilters==0.4.0
 django-multiselectfield==0.1.12
 django-ranged-response==0.2.0
-django-recaptcha==3.0.0
+django-recaptcha
 django-resized==0.3.11
 django-shapeshifter==18.9.23
 # django-simple-captcha==0.5.13
@@ -79,7 +79,7 @@ docutils==0.18.1
 dparse==0.5.1
 drf-spectacular>=0.24.2,<0.25
 edtf==4.0.1
-elastic-wikidata==1.0.1
+elastic-wikidata
 elasticsearch==7.8.1
 elasticsearch-dsl==7.4.0
 elasticsearch7==7.17.1
@@ -197,7 +197,7 @@ rfc3986==2.0.0
 rich==12.0.0
 s3transfer==0.5.2
 scipy==1.8.0
-selenium==4.1.3
+selenium
 Shapely==2.0
 shellingham==1.4.0
 simpleeval==0.9.12

--- a/whg/settings.py
+++ b/whg/settings.py
@@ -8,6 +8,12 @@ from celery.schedules import crontab
 from django.contrib.messages import constants as messages
 from logging.handlers import RotatingFileHandler
 
+try:
+  SECRET_KEY
+except NameError:
+  SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
+
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/


### PR DESCRIPTION
# Test results: https://github.com/cclauss/whgazetteer/actions

---
INFO: pip is looking at multiple versions of elastic-wikidata to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements397.txt (line 17), -r requirements397.txt (line 36), -r requirements397.txt (line 43), -r requirements397.txt (line 82) and click because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested click
    black 22.1.0 depends on click>=8.0.0
    cligj 0.7.2 depends on click>=4.0
    datapackage 1.15.2 depends on click>=6.7
    elastic-wikidata 1.0.1 depends on click==7.1.2
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
---
django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.

---
% `uv pip install -r requirements397.txt`
```
Resolved 250 packages in 21.27s
Downloaded 248 packages in 37.37s
```
...
```
Resolved 250 packages in 6.61s
Downloaded 248 packages in 22.66s
Installed 250 packages in 553ms
```